### PR TITLE
Fix physio track error when showing too many points

### DIFF
--- a/Assets/Runtime/Resources/UI/Uxml/timeline_physio_track.uxml
+++ b/Assets/Runtime/Resources/UI/Uxml/timeline_physio_track.uxml
@@ -1,42 +1,26 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" editor-extension-mode="False">
-    <Style src="project://database/Packages/fr.liris.plume.viewer/Runtime/Resources/UI/Styles/global.uss?fileID=7433441132597879392&amp;guid=ab73a4b1d27dd8b4f9ec2a5bd75e9cbf&amp;type=3#global"/>
-    <Style src="project://database/Packages/fr.liris.plume.viewer/Runtime/Resources/UI/Styles/dark_theme.uss?fileID=7433441132597879392&amp;guid=028e63fb930a6f74997dbdd7944d219b&amp;type=3#dark_theme"/>
-    <ui:VisualElement name="track"
-                      style="flex-grow: 0; flex-direction: row; width: 100%; max-width: 100%; min-width: 100%; flex-shrink: 0; height: 80px; border-bottom-width: 1px; border-left-color: rgb(48, 48, 48); border-right-color: rgb(48, 48, 48); border-top-color: rgb(48, 48, 48); border-bottom-color: rgb(48, 48, 48);">
-        <ui:VisualElement name="track-header" class="panel-container-primary"
-                          style="flex-grow: 0; width: 400px; flex-shrink: 0; border-left-color: rgb(48, 48, 48); border-right-color: rgb(48, 48, 48); border-top-color: rgb(48, 48, 48); border-bottom-color: rgb(48, 48, 48); border-top-width: 0; border-left-width: 0; border-bottom-width: 0; flex-direction: row;">
-            <ui:VisualElement name="color"
-                              style="flex-grow: 0; background-color: rgba(0, 0, 0, 0); flex-shrink: 0; width: 5px; margin-right: 5px;"/>
+    <Style src="project://database/Assets/Runtime/Resources/UI/Styles/global.uss?fileID=7433441132597879392&amp;guid=ab73a4b1d27dd8b4f9ec2a5bd75e9cbf&amp;type=3#global" />
+    <Style src="project://database/Assets/Runtime/Resources/UI/Styles/dark_theme.uss?fileID=7433441132597879392&amp;guid=028e63fb930a6f74997dbdd7944d219b&amp;type=3#dark_theme" />
+    <ui:VisualElement name="track" style="flex-grow: 0; flex-direction: row; width: 100%; max-width: 100%; min-width: 100%; flex-shrink: 0; height: 80px; border-bottom-width: 1px; border-left-color: rgb(48, 48, 48); border-right-color: rgb(48, 48, 48); border-top-color: rgb(48, 48, 48); border-bottom-color: rgb(48, 48, 48);">
+        <ui:VisualElement name="track-header" class="panel-container-primary" style="flex-grow: 0; width: 400px; flex-shrink: 0; border-left-color: rgb(48, 48, 48); border-right-color: rgb(48, 48, 48); border-top-color: rgb(48, 48, 48); border-bottom-color: rgb(48, 48, 48); border-top-width: 0; border-left-width: 0; border-bottom-width: 0; flex-direction: row;">
+            <ui:VisualElement name="color" style="flex-grow: 0; background-color: rgba(0, 0, 0, 0); flex-shrink: 0; width: 5px; margin-right: 5px;" />
             <ui:VisualElement style="flex-grow: 1; background-color: rgba(0, 0, 0, 0);">
-                <ui:VisualElement
-                        style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); flex-direction: row; align-items: center;">
-                    <ui:Label tabindex="-1" text="Stream Name" display-tooltip-when-elided="true" name="name"
-                              style="-unity-font-style: bold; flex-shrink: 1; flex-grow: 0; justify-content: center;"/>
-                    <ui:Label tabindex="-1" text="(Channel 0)" display-tooltip-when-elided="true" name="channel"
-                              style="flex-shrink: 1; flex-grow: 0; justify-content: center;"/>
+                <ui:VisualElement style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); flex-direction: row; align-items: center;">
+                    <ui:Label tabindex="-1" text="Stream Name" display-tooltip-when-elided="true" name="name" style="-unity-font-style: bold; flex-shrink: 1; flex-grow: 0; justify-content: center;" />
+                    <ui:Label tabindex="-1" text="(Channel 0)" display-tooltip-when-elided="true" name="channel" style="flex-shrink: 1; flex-grow: 0; justify-content: center;" />
                 </ui:VisualElement>
-                <ui:VisualElement
-                        style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); justify-content: flex-start; flex-direction: row; align-items: center;">
-                    <ui:Label tabindex="-1" text="Frequency: 50Hz" display-tooltip-when-elided="true" name="frequency"
-                              style="flex-grow: 1; flex-shrink: 1; justify-content: center;"/>
+                <ui:VisualElement style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); justify-content: flex-start; flex-direction: row; align-items: center;">
+                    <ui:Label tabindex="-1" text="Frequency: 50Hz" display-tooltip-when-elided="true" name="frequency" style="flex-grow: 1; flex-shrink: 1; justify-content: center;" />
                 </ui:VisualElement>
-                <ui:VisualElement
-                        style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); flex-direction: row; align-items: center;">
-                    <ui:Label tabindex="-1" text="Min: 0.345" display-tooltip-when-elided="true" name="min-value"
-                              style="justify-content: center;"/>
-                    <ui:Label tabindex="-1" text="Max: 0.345" display-tooltip-when-elided="true" name="max-value"
-                              style="justify-content: center;"/>
-                    <ui:Label tabindex="-1" text="Nearest: 0.345" display-tooltip-when-elided="true"
-                              name="current-value" style="justify-content: center;"/>
+                <ui:VisualElement style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); flex-direction: row; align-items: center;">
+                    <ui:Label tabindex="-1" text="Min: 0.345" display-tooltip-when-elided="true" name="min-value" style="justify-content: center;" />
+                    <ui:Label tabindex="-1" text="Max: 0.345" display-tooltip-when-elided="true" name="max-value" style="justify-content: center;" />
+                    <ui:Label tabindex="-1" text="Nearest: 0.345" display-tooltip-when-elided="true" name="current-value" style="justify-content: center;" />
                 </ui:VisualElement>
             </ui:VisualElement>
         </ui:VisualElement>
-        <ui:ScrollView name="track-content-container" horizontal-scroller-visibility="Hidden"
-                       vertical-scroller-visibility="Hidden" class="panel-container-secondary" style="width: 100%;">
-            <ui:VisualElement name="track-content" style="flex-grow: 1; height: 100%; width: 100%;">
-                <ui:VisualElement name="canvas"
-                                  style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); flex-shrink: 0; height: 100%; width: 100%;"/>
-            </ui:VisualElement>
+        <ui:ScrollView name="track-content-container" horizontal-scroller-visibility="Hidden" vertical-scroller-visibility="Hidden" class="panel-container-secondary" style="width: 100%;">
+            <ui:VisualElement name="track-content" style="flex-grow: 1; height: 100%; width: 100%;" />
         </ui:ScrollView>
     </ui:VisualElement>
 </ui:UXML>

--- a/Assets/Runtime/Scripts/Viewer/MainWindowUI.cs
+++ b/Assets/Runtime/Scripts/Viewer/MainWindowUI.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
-using PLUME.Sample;
 using PLUME.Sample.Common;
 using PLUME.Sample.LSL;
 using PLUME.UI.Element;
@@ -242,13 +241,20 @@ namespace PLUME.Viewer
                     continue;
 
                 Random.InitState(streamName.GetHashCode());
-                var streamColor = Random.ColorHSV(0f, 1f, 1f, 1f, 0.5f, 1f);
+                var streamColorHue = Random.value;
+                var streamColor = Color.HSVToRGB(streamColorHue, 1f, 1f);
                 var channelsTrack = new TimelinePhysiologicalSignalTrackElement[channelCount];
 
                 for (var channelIdx = 0; channelIdx < channelCount; channelIdx++)
                 {
-                    Random.InitState((streamName + channelIdx).GetHashCode());
-                    var channelColor = Random.ColorHSV(0f, 1f, 1f, 1f, 0.5f, 1f);
+                    var hueVariant = streamColorHue + channelIdx * 0.1f;
+
+                    if (hueVariant > 1)
+                    {
+                        hueVariant -= (int) hueVariant;
+                    }
+                    
+                    var channelColor = Color.HSVToRGB(hueVariant, 1f, 1f);
                     channelsTrack[channelIdx] = new TimelinePhysiologicalSignalTrackElement();
                     channelsTrack[channelIdx].SetName(streamName);
                     channelsTrack[channelIdx].SetFrequency(nominalSamplingRate);
@@ -284,41 +290,61 @@ namespace PLUME.Viewer
                         switch (sample.ValuesCase)
                         {
                             case StreamSample.ValuesOneofCase.FloatValues:
-                                min = Math.Min(min, sample.FloatValues.Value[channelIdx]);
-                                max = Math.Max(max, sample.FloatValues.Value[channelIdx]);
-                                points.Add(
-                                    new Vector2(unpackedSample.Timestamp, sample.FloatValues.Value[channelIdx]));
+                            {
+                                var val = sample.FloatValues.Value[channelIdx];
+                                
+                                if(float.IsNaN(val))
+                                    continue;
+                                
+                                min = Math.Min(min, val);
+                                max = Math.Max(max, val);
+                                points.Add(new Vector2(unpackedSample.Timestamp, val));
                                 break;
+                            }
                             case StreamSample.ValuesOneofCase.DoubleValues:
-                                min = Math.Min(min, (float)sample.DoubleValues.Value[channelIdx]);
-                                max = Math.Max(max, (float)sample.DoubleValues.Value[channelIdx]);
-                                points.Add(new Vector2(unpackedSample.Timestamp,
-                                    (float)sample.DoubleValues.Value[channelIdx]));
+                            {
+                                var val = (float) sample.DoubleValues.Value[channelIdx];
+                                
+                                if(float.IsNaN(val))
+                                    continue;
+                                
+                                min = Math.Min(min, val);
+                                max = Math.Max(max, val);
+                                points.Add(new Vector2(unpackedSample.Timestamp, val));
                                 break;
+                            }
                             case StreamSample.ValuesOneofCase.Int8Values:
-                                min = Math.Min(min, sample.Int8Values.Value[channelIdx]);
-                                max = Math.Max(max, sample.Int8Values.Value[channelIdx]);
-                                points.Add(new Vector2(unpackedSample.Timestamp,
-                                    sample.Int8Values.Value[channelIdx]));
+                            {
+                                var val = sample.Int8Values.Value[channelIdx];
+                                min = Math.Min(min, val);
+                                max = Math.Max(max, val);
+                                points.Add(new Vector2(unpackedSample.Timestamp, val));
                                 break;
+                            }
                             case StreamSample.ValuesOneofCase.Int16Values:
-                                min = Math.Min(min, sample.Int16Values.Value[channelIdx]);
-                                max = Math.Max(max, sample.Int16Values.Value[channelIdx]);
-                                points.Add(
-                                    new Vector2(unpackedSample.Timestamp, sample.Int16Values.Value[channelIdx]));
+                            {
+                                var val = sample.Int16Values.Value[channelIdx];
+                                min = Math.Min(min, val);
+                                max = Math.Max(max, val);
+                                points.Add(new Vector2(unpackedSample.Timestamp, val));
                                 break;
+                            }
                             case StreamSample.ValuesOneofCase.Int32Values:
-                                min = Math.Min(min, sample.Int32Values.Value[channelIdx]);
-                                max = Math.Max(max, sample.Int32Values.Value[channelIdx]);
-                                points.Add(
-                                    new Vector2(unpackedSample.Timestamp, sample.Int32Values.Value[channelIdx]));
+                            {
+                                var val = sample.Int32Values.Value[channelIdx];
+                                min = Math.Min(min, val);
+                                max = Math.Max(max, val);
+                                points.Add(new Vector2(unpackedSample.Timestamp, val));
                                 break;
+                            }
                             case StreamSample.ValuesOneofCase.Int64Values:
-                                min = Math.Min(min, sample.Int64Values.Value[channelIdx]);
-                                max = Math.Max(max, sample.Int64Values.Value[channelIdx]);
-                                points.Add(
-                                    new Vector2(unpackedSample.Timestamp, sample.Int64Values.Value[channelIdx]));
+                            {
+                                var val = sample.Int64Values.Value[channelIdx];
+                                min = Math.Min(min, val);
+                                max = Math.Max(max, val);
+                                points.Add(new Vector2(unpackedSample.Timestamp, val));
                                 break;
+                            }
                             case StreamSample.ValuesOneofCase.None:
                             case StreamSample.ValuesOneofCase.StringValues:
                                 break;


### PR DESCRIPTION
Unity Painter2D restricts VisualElement to have at most 65535 vertices, leading to an error when too many physiological points are visualized in the physiological tracks.

https://issuetracker-mig.prd.it.unity3d.com/issues/a-visualelement-must-not-allocate-more-than-65535-vertices-error-appears-when-trying-to-draw-a-map-with-painter2d

This fix contains a naïve solution that simply splits the visual into several visual elements to mitigate the issue.